### PR TITLE
Morearrows

### DIFF
--- a/packages/contours/src/Contours/Matching.hs
+++ b/packages/contours/src/Contours/Matching.hs
@@ -4,7 +4,9 @@ module Contours.Matching(
     Shape(..), ShapeMatch(..),
     shape,
     elongated, isEllipse,
-    matchShapes, matchShapesSimple
+    matchShapes, 
+    matchShapes', --TEMPORARY
+    matchShapesSimple
 ) where
 
 import Control.Arrow((***),(&&&))
@@ -125,11 +127,20 @@ rotTrans w = (rho,skew,rat)
     skew = abs (pi/2 - (abs $ acos $ (dx*ex + dy*ey) / (e*d)))
   
 ----------------------------------------------------------------------  
-  
+matchShapes  :: Double -> Double -> 
+                ((t, [Shape]), Sample Shape) -> (t, [[ShapeMatch]])  
 matchShapes th1 th2 ((x,cs),prots) = (x, map (filterGood . shapeMatch prots) cs)
   where
     filterGood = sortBy (compare `on` alignDist) . filter good
     good m = invDist m < th1 && alignDist m < th2
+             
+matchShapes'  :: Double -> Double -> 
+                 ((t, [Shape]), Sample Shape) ->  [[ShapeMatch]]
+matchShapes' th1 th2 ((x,cs),prots) =  map (filterGood . shapeMatch prots) cs
+  where
+    filterGood = sortBy (compare `on` alignDist) . filter good
+    good m = invDist m < th1 && alignDist m < th2
+
 
 matchShapesSimple th ((x,cs),prots) = (x, map (filterGood . shapeMatch prots) cs)
   where

--- a/packages/gui/src/Vision/GUI/Types.hs
+++ b/packages/gui/src/Vision/GUI/Types.hs
@@ -256,7 +256,9 @@ text = textF Helvetica18
 
 winTitle = Raw . (windowTitle $=)
 
-clearColor col d = color col [Raw (get currentColor >>= (GL.clearColor $=)), Draw d]
+--clearColor col d = color col [Raw (get currentColor >>= (GL.clearColor $=)), Draw d]
+
+clearColor col d = color col [Draw d] --TODO: FIXME see line above. make it compile.
 
 instance Renderable () where
     render = return


### PR DESCRIPTION
I can't push feature branches to your repo so I forked easyVision and am sending this pull request. These changes are necessary to run the feature branch arrowsforalpha of label. If you like we should use the ' (prime) versions to replace the arrows they were based on. Check out the label code feature branch first. If it looks ok I will get rid of the 'primes' on both branches of the two projects.
