### PR TITLE
fixed OpenCV compiling error when trying to set Mat to ambiguous type 0

### DIFF
--- a/packages/ip/opencv/src/OpenCV/opencv2.cpp
+++ b/packages/ip/opencv/src/OpenCV/opencv2.cpp
@@ -106,6 +106,7 @@ int cFindHomography(int code, double th,
 
     cv::Mat h(rr,cr,CV_64F,pr);
     cv::Mat mask(nmask,1,CV_8U,pmask);
+    cv::Scalar zero = 0;
 
     int method;
     switch(code) {
@@ -114,7 +115,7 @@ int cFindHomography(int code, double th,
         default: method = 0;
     }
 
-    mask=0;
+    mask=zero;
 
     if (code==3) {
         h = cv::estimateRigidTransform(objectPoints,imagePoints,false);


### PR DESCRIPTION
Some versions of OpenCV/C++ compiler require to specify the type of the scalar 0 in the  Mat mask = 0 assignment